### PR TITLE
Add a docker-compose config and maintenance scripts

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,0 +1,106 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Sascha Vogt <sascha@vogt-neuenbuerg.de>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# ATTENTION: Make sure to have the "versioneye-base.yml" already started, as it contains
+#            the base containers (rabbitmq, memcached, elasticsearch and mongodb) which
+#            are linked here!
+#
+# $COMPOSE_PROJECT_NAME sets the prefix for all VMs. Should be set to make the names unique.
+# If you want to scale a particular container, comment out the "container_name" property!
+# The following environment variables have to be set to the current versions you want to use:
+#     $VERSION_RAILS_APP
+#     $VERSION_RAILS_API
+#     $VERSION_TASKS
+#     $VERSION_CRAWLJ
+#     $VERSION_CRAWLJ_WORKER
+
+# Web Application
+rails_app:
+  image: versioneye/rails_app:${VERSION_RAILS_APP}
+  container_name: rails_app
+  restart: always
+  ports:
+   - "8080:8080"
+  volumes:
+   - /mnt/logs:/app/log
+  external_links:
+   - rabbitmq:rm
+   - memcached:mc
+   - elasticsearch:es
+   - mongodb:db
+
+# VersionEye API
+rails_api:
+  image: versioneye/rails_api:${VERSION_RAILS_API}
+  container_name: rails_api
+  restart: always
+  ports:
+   - "9090:9090"
+  volumes:
+   - /mnt/logs:/app/log
+  external_links:
+   - rabbitmq:rm
+   - memcached:mc
+   - elasticsearch:es
+   - mongodb:db
+
+# Background jobs triggered by WebApp & API + scheduled jobs
+tasks:
+  image: versioneye/tasks:${VERSION_TASKS}
+  container_name: tasks
+  restart: always
+  volumes:
+   - /mnt/logs:/app/log
+  external_links:
+   - rabbitmq:rm
+   - memcached:mc
+   - elasticsearch:es
+   - mongodb:db
+
+# Java crawler indexer
+crawlj:
+  image: versioneye/crawlj:${VERSION_CRAWLJ}
+  container_name: crawlj
+  restart: always
+  volumes:
+   - /mnt/logs:/mnt/logs
+  external_links:
+   - rabbitmq:rm
+   - memcached:mc
+   - elasticsearch:es
+   - mongodb:db
+
+# Java crawler worker. Performs the hard work!
+crawlj_worker:
+  image: versioneye/crawlj_worker:${VERSION_CRAWLJ_WORKER}
+  #container_name: crawlj_worker      # Comment in if you don't want to scale the worker
+  restart: always
+  volumes:
+   - /mnt/logs:/mnt/logs
+  external_links:
+   - rabbitmq:rm
+   - memcached:mc
+   - elasticsearch:es
+   - mongodb:db
+

--- a/docker-compose/versioneye-base.yml
+++ b/docker-compose/versioneye-base.yml
@@ -1,0 +1,55 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Sascha Vogt <sascha@vogt-neuenbuerg.de>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# $COMPOSE_PROJECT_NAME sets the prefix for all VMs. Should be set to make the names unique
+# If you want to scale a particular container, comment out the "container_name" property!
+
+# AMQ Message Server
+rabbitmq:
+  image: reiz/rabbitmq:3.4.2
+  container_name: rabbitmq
+  restart: always
+
+# Cache
+memcached:
+  image: reiz/memcached:1.4.14
+  container_name: memcached
+  restart: always
+
+# Fuzzy search
+elasticsearch:
+  image: reiz/elasticsearch:0.9.1
+  container_name: elasticsearch
+  restart: always
+  volumes:
+   - /mnt/elasticsearch:/data
+
+# Primary DB. The single source of truth!
+mongodb:
+  image: reiz/mongodb:3.2.0
+  container_name: mongodb
+  restart: always
+  volumes:
+   - /mnt/mongodb:/data
+

--- a/python/get-latest-versions
+++ b/python/get-latest-versions
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Sascha Vogt <sascha@vogt-neuenbuerg.de>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+import json;
+import urllib;
+
+url="https://www.versioneye.com/docker/remote_images.json";
+f=urllib.urlopen(url);
+dict=json.load(f);
+keys=dict.keys();
+keys.sort();
+for k in keys:
+    print k;

--- a/shell/docker-mon
+++ b/shell/docker-mon
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Sascha Vogt <sascha@vogt-neuenbuerg.de>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+CONTAINER=$(docker ps --format '{{.Names}}' | sort | tr '\n' ' ')
+
+echo "Stats for the following containers: ${CONTAINER}"
+docker stats $CONTAINER

--- a/shell/versioneye-update
+++ b/shell/versioneye-update
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Sascha Vogt <sascha@vogt-neuenbuerg.de>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# Config
+DOCKER=/usr/bin/docker
+DOCKER_COMPOSE=/usr/local/bin/docker-compose
+DOCKER_COMPOSE_YAML=/root/docker-compose.yml
+
+LATEST_VERSIONS=`get-latest-versions`
+
+
+COMPOSE_HTTP_TIMEOUT=180
+COMPOSE_PROJECT_NAME=versioneye
+
+export COMPOSE_HTTP_TIMEOUT=$COMPOSE_HTTP_TIMEOUT
+export COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
+
+for version in `echo "$LATEST_VERSIONS" | sed 's/.*\//VERSION_/' | sed 's/:/=/' | tr '[:lower:]' '[:upper:]'`; do
+    eval "export $version";
+done
+
+for image in $LATEST_VERSIONS; do
+    $DOCKER pull $image
+done
+
+$DOCKER_COMPOSE -f $DOCKER_COMPOSE_YAML up -d


### PR DESCRIPTION
A sample docker-compose.yml (and a versioneye-base.yml) for launching
Versioneye via docker-compose. In addition a little Python script which
checks the latest versions from upstream. Finally a small update shell
script which uses the latest versions and updates the application.

docker-mon lists all currently running Docker containers and tracks them
via "docker stats".
