### PR TITLE
Correctly detect docker-compose binary

### DIFF
--- a/versioneye-stop
+++ b/versioneye-stop
@@ -34,7 +34,14 @@ then
    DOCKER=/usr/local/bin/docker
 fi
 
-DOCKER_COMPOSE=/usr/local/bin/docker-compose
+DOCKER_COMPOSE=/usr/bin/docker-compose
+
+if [ -f "/usr/local/bin/docker" ];
+then
+   echo "Found docker-compose binary at /usr/local/bin/docker-compose"
+   DOCKER_COMPOSE=/usr/local/bin/docker-compose
+fi
+
 DOCKER_COMPOSE_YAML=docker-compose.yml
 
 LATEST_VERSIONS=`./get-latest-versions`

--- a/versioneye-update
+++ b/versioneye-update
@@ -35,7 +35,14 @@ then
    DOCKER=/usr/local/bin/docker
 fi
 
-DOCKER_COMPOSE=/usr/local/bin/docker-compose
+DOCKER_COMPOSE=/usr/bin/docker-compose
+
+if [ -f "/usr/local/bin/docker" ];
+then
+   echo "Found docker-compose binary at /usr/local/bin/docker-compose"
+   DOCKER_COMPOSE=/usr/local/bin/docker-compose
+fi
+
 DOCKER_COMPOSE_YAML=docker-compose.yml
 
 LATEST_VERSIONS=`./get-latest-versions`


### PR DESCRIPTION
When installed via package manager, the docker-compose may lay in `/usr/bin/docker-compose`, otherwise in `/usr/local/bin/docker-compose`.
