### PR TITLE
Instructions to install docker engine and docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,35 @@ The VersionEye host will need the following ports open:
 | 22  | SSH | Host management     |
 
 
-## Environment
+## Environment dependencies
 
-The scripts in this repository are all tested with Docker for Linux on Ubuntu 14.04. The update and stop scripts require that [jq](https://stedolan.github.io/jq/) is installed. On Ubuntu you can install it like this:
+The scripts in this repository are all tested with Docker for Linux on Ubuntu 14.04. The update and stop scripts require that [jq](https://stedolan.github.io/jq/) is installed.
 
+### Installing jq
+
+On Ubuntu you can install it by running the following command on the terminal:
 ```
 apt-get install jq
+```
+
+Alternatively you can also check the official [jq docs](https://stedolan.github.io/jq/)
+
+### Installing docker and docker-compose
+
+Follow these guides to install docker and docker-compose:
+ - [Installing docker engine in Ubuntu](https://docs.docker.com/engine/installation/linux/ubuntulinux/) ([or other distributions](https://docs.docker.com/engine/installation/))
+ - [Installing docker-compose](https://docs.docker.com/compose/install/)
+
+Make sure you've tested the docker dependencies before moving to the net next. On Ubuntu you can test them by running:
+
+```
+sudo docker run hello-world
+```
+
+and:
+
+```
+docker-compose --version
 ```
 
 ## Start backend services for VersionEye

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ Download the `versioneye-base.yml` and the other utility files:
 
 ```
 curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-base.yml
-curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-start
+curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-update
 curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-stop
 ```
 
 Set write permission to the start and stop scripts:
 
 ```
-chmod +x versioneye-start versioneye-stop
+chmod +x versioneye-update versioneye-stop
 
 ```
 Start the docker containers:

--- a/README.md
+++ b/README.md
@@ -62,12 +62,18 @@ VersionEye is currently using this backend systems:
   - ElasticSearch
   - Memcached
 
-They are all available as Docker images from Docker Hub. There is a file `versioneye-base.yml`
-for [Docker Compose](https://docs.docker.com/compose/).
-You can start all backend systems like this:
+These are all available as Docker images from Docker Hub. To simplify things you can grab the `versioneye-base.yml` on the root of this repository to use with [Docker Compose](https://docs.docker.com/compose/).
+
+Download the `versioneye-base.yml` file:
 
 ```
-docker-compose -f versioneye-base.yml up -d
+curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-base.yml
+```
+
+Start all the backend systems by running:
+
+```
+sudo docker-compose -f versioneye-base.yml up -d
 ```
 
 That will start all 4 Docker containers in deamon mode.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Scripts for [VersionEye](https://www.versioneye.com) operations. Everybody can c
 
 Clone this repository and `cd` into it:
 
-`git clone https://github.com/versioneye/ops_contrib.git ** cd ops_contrib`
+`git clone https://github.com/versioneye/ops_contrib.git && cd ops_contrib`
 
 Some of the commands and files below are found on the root of this repository, thus cloning the repository is the easier way to get access to them. Alternatively you can download the files or use the [repository archive](https://github.com/versioneye/ops_contrib/archive/master.zip).
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Download the `versioneye-base.yml` and the other utility files:
 curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-base.yml
 curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-update
 curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-stop
+curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/docker-compose.yml
 ```
 
 Set write permission to the start and stop scripts:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Scripts for [VersionEye](https://www.versioneye.com) operations. Everybody can contribute!
 
+## Starting point
+
+Clone this repository and `cd` into it:
+
+`git clone https://github.com/versioneye/ops_contrib.git ** cd ops_contrib`
+
+Some of the commands and files below are found on the root of this repository, thus cloning the repository is the easier way to get access to them. Alternatively you can download the files or use the [repository archive](https://github.com/versioneye/ops_contrib/archive/master.zip).
+
 ## System requirements
 
 We recommend a minimum resource configuration of:
@@ -65,23 +73,9 @@ VersionEye is currently using this backend systems:
   - ElasticSearch
   - Memcached
 
-These are all available as Docker images from Docker Hub. To simplify things you can grab the `versioneye-base.yml` on the root of this repository to use with [Docker Compose](https://docs.docker.com/compose/).
 
-Download the `versioneye-base.yml` and the other utility files:
+These are all available as Docker images from Docker Hub. This repository contains a file `versioneye-base.yml` for Docker Compose. You can start all backend systems like this:
 
-```
-curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-base.yml
-curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-update
-curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-stop
-curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/docker-compose.yml
-```
-
-Set write permission to the start and stop scripts:
-
-```
-chmod +x versioneye-update versioneye-stop
-
-```
 Start the docker containers:
 
 ```

--- a/README.md
+++ b/README.md
@@ -67,13 +67,21 @@ VersionEye is currently using this backend systems:
 
 These are all available as Docker images from Docker Hub. To simplify things you can grab the `versioneye-base.yml` on the root of this repository to use with [Docker Compose](https://docs.docker.com/compose/).
 
-Download the `versioneye-base.yml` file:
+Download the `versioneye-base.yml` and the other utility files:
 
 ```
 curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-base.yml
+curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-start
+curl -L -O https://raw.githubusercontent.com/versioneye/ops_contrib/master/versioneye-stop
 ```
 
-Start all the backend systems by running:
+Set write permission to the start and stop scripts:
+
+```
+chmod +x versioneye-start versioneye-stop
+
+```
+Start the docker containers:
 
 ```
 sudo docker-compose -f versioneye-base.yml up -d
@@ -82,10 +90,9 @@ sudo docker-compose -f versioneye-base.yml up -d
 That will start all 4 Docker containers in deamon mode.
 The MongoDB and ElasticSearch container is not persistent! If the Docker containers are
 getting stopped/killed the data is lost. For persistence you need to comment in the
-mount volumes in the `versioneye-base.yml` file and adjust the paths to a directory on the
-host system.
+mount volumes in the `versioneye-base.yml` file and adjust the paths to a directory on the host system.
 
-To stop backend services you can run
+To stop backend services you can run:
 
 ```sh
 docker-compose -f versioneye-base.yml down

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ The VersionEye host will need the following ports open:
 
 ## Environment dependencies
 
-The scripts in this repository are all tested with Docker for Linux on Ubuntu 14.04. The update and stop scripts require that [jq](https://stedolan.github.io/jq/) is installed.
+The scripts in this repository are all tested with Docker for Linux on Ubuntu 14.04. This instalation guide requires that you have the following libraries installed:
+ - jq
+ - docker
+ - docker-compose
 
 ### Installing jq
 


### PR DESCRIPTION
Hey @reiz,

I was following the guide and I noticed it that although the install guide depends on`jq`, `docker` and `docker-compose` it only has the details on how to install `jq`.

This PR:
- Creates a doc hierarchy on the environment dependencies
- Adds the instructions (or links) to the official `docker` and `docker-compose` guides
- Adds a bit of testing to validate the docker dependencies (although this is part of the guides themselves)

Let me know if you want me to change this in anyway.

:octocat::heart: 
